### PR TITLE
Fix PlanePage context usage

### DIFF
--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -199,10 +199,9 @@ class PlanePage extends ConsumerWidget {
               )
               : SingleChildScrollView(
                 padding: slotPadding,
-                child:
-                    isLowerDeck
-                        ? _buildLowerDeckLayout(ref, isOutbound)
-                        : _buildLayout(ref, sequence, isOutbound),
+                child: isLowerDeck
+                    ? _buildLowerDeckLayout(context, ref, isOutbound)
+                    : _buildLayout(context, ref, sequence, isOutbound),
               ),
     );
   }
@@ -221,7 +220,12 @@ class PlanePage extends ConsumerWidget {
     );
   }
 
-  Widget _buildLayout(WidgetRef ref, LoadingSequence sequence, bool outbound) {
+  Widget _buildLayout(
+    BuildContext context,
+    WidgetRef ref,
+    LoadingSequence sequence,
+    bool outbound,
+  ) {
     final plane = ref.watch(planeProvider);
     final slots = outbound ? plane.outboundSlots : plane.inboundSlots;
     final columns = _columnCount(sequence);
@@ -367,7 +371,11 @@ class PlanePage extends ConsumerWidget {
     );
   }
 
-  Widget _buildLowerDeckLayout(WidgetRef ref, bool outbound) {
+  Widget _buildLowerDeckLayout(
+    BuildContext context,
+    WidgetRef ref,
+    bool outbound,
+  ) {
     final deck = ref.watch(lowerDeckProvider);
     final slots = outbound ? deck.outboundSlots : deck.inboundSlots;
     const labels = [


### PR DESCRIPTION
## Summary
- pass BuildContext into layout helper functions in plane_page.dart

## Testing
- *No tests run due to missing Flutter/Dart tooling*

------
https://chatgpt.com/codex/tasks/task_e_6872a668b6cc8331a0c53381214ecb16