### PR TITLE
Implement transfer cut/paste behavior

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -98,7 +98,7 @@ class _HomeNavState extends State<HomeNav> {
       bottomNavigationBar: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const TransferArea(),
+          if (page != 0) const TransferArea(),
           Container(
             decoration: const BoxDecoration(
               border: Border(top: BorderSide(color: Colors.white, width: 1)),

--- a/lib/providers/ball_deck_provider.dart
+++ b/lib/providers/ball_deck_provider.dart
@@ -121,6 +121,32 @@ class BallDeckNotifier extends StateNotifier<BallDeckState> {
     _saveState();
   }
 
+  // Remove a ULD from anywhere on the ball deck or overflow by id
+  void removeContainer(StorageContainer container) {
+    final newSlots = [
+      for (final slot in state.slots)
+        if (slot?.id == container.id) null else slot
+    ];
+
+    final newOverflow = [
+      for (int i = 0; i < state.overflow.length; i++)
+        state.overflow[i].id == container.id
+            ? StorageContainer(
+                id: 'EMPTY_SLOT_$i',
+                uld: 'EMPTY_SLOT_$i',
+                type: SizeEnum.EMPTY,
+                size: SizeEnum.PAG_88x125,
+                weightKg: 0,
+                hasDangerousGoods: false,
+                colorIndex: null,
+              )
+            : state.overflow[i]
+    ];
+
+    state = BallDeckState(slots: newSlots, overflow: newOverflow);
+    _saveState();
+  }
+
   void _saveState() {
     // You can implement Hive or other persistence logic here
   }

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -35,4 +35,13 @@ class StorageNotifier extends StateNotifier<List<StorageContainer?>> {
     newState.add(container); // Overflow behavior (expand list)
     state = newState;
   }
+
+  // Remove a ULD from storage by id
+  void removeContainer(StorageContainer container) {
+    final newState = [
+      for (final slot in state)
+        if (slot?.id == container.id) null else slot
+    ];
+    state = newState;
+  }
 }

--- a/lib/providers/train_provider.dart
+++ b/lib/providers/train_provider.dart
@@ -88,4 +88,23 @@ class TrainNotifier extends StateNotifier<List<Train>> {
     state = trains;
     _saveState();
   }
+
+  // Remove a ULD from any train dolly by id
+  void removeContainer(StorageContainer container) {
+    final trains = [...state];
+    bool changed = false;
+    for (int t = 0; t < trains.length; t++) {
+      final train = trains[t];
+      for (int i = 0; i < train.dollys.length; i++) {
+        if (train.dollys[i].load?.id == container.id) {
+          train.dollys[i] = Dolly(train.dollys[i].idx); // clear
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      state = trains;
+      _saveState();
+    }
+  }
 }

--- a/lib/widgets/transfer_area.dart
+++ b/lib/widgets/transfer_area.dart
@@ -3,6 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/container.dart';
 import '../providers/transfer_queue_provider.dart';
+import '../providers/ball_deck_provider.dart';
+import '../providers/train_provider.dart';
+import '../providers/storage_provider.dart';
+import '../providers/plane_provider.dart';
+import '../providers/lower_deck_provider.dart';
 
 class TransferArea extends ConsumerWidget {
   const TransferArea({super.key});
@@ -12,6 +17,22 @@ class TransferArea extends ConsumerWidget {
     final queue = ref.watch(transferQueueProvider);
     return DragTarget<StorageContainer>(
       onAccept: (c) {
+        // Remove the ULD from wherever it currently resides
+        ref.read(ballDeckProvider.notifier).removeContainer(c);
+        ref.read(storageProvider.notifier).removeContainer(c);
+        ref.read(trainProvider.notifier).removeContainer(c);
+        ref.read(planeProvider.notifier).removeContainer(c, outbound: true);
+        ref.read(planeProvider.notifier).removeContainer(c, outbound: false);
+        ref
+            .read(planeProvider.notifier)
+            .removeLowerDeckContainer(c, outbound: true);
+        ref
+            .read(planeProvider.notifier)
+            .removeLowerDeckContainer(c, outbound: false);
+        ref.read(lowerDeckProvider.notifier).removeContainer(c, outbound: true);
+        ref.read(lowerDeckProvider.notifier).removeContainer(c, outbound: false);
+
+        // Finally add it to the transfer queue
         ref.read(transferQueueProvider.notifier).add(c);
       },
       builder: (context, cand, rej) {


### PR DESCRIPTION
## Summary
- hide transfer area on Config page
- add `removeContainer` helpers for deck, storage, and trains
- update transfer bin to cut ULDs from all pages before queuing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872eaf352588331aded52e00906002c