### PR TITLE
Fix ULD move duplication

### DIFF
--- a/lib/pages/ball_deck_page.dart
+++ b/lib/pages/ball_deck_page.dart
@@ -9,6 +9,7 @@ import '../widgets/uld_chip.dart';
 import '../models/aircraft.dart';
 import '../widgets/slot_layout_constants.dart';
 import '../widgets/transfer_menu.dart';
+import '../utils/uld_mover.dart';
 
 class BallDeckPage extends ConsumerWidget {
   const BallDeckPage({super.key});
@@ -94,6 +95,7 @@ class BallDeckPage extends ConsumerWidget {
           : null,
       child: DragTarget<model.StorageContainer>(
         onAccept: (container) {
+          removeFromAll(ref, container);
           ref.read(ballDeckProvider.notifier).placeContainer(slotIdx, container);
         },
         builder: (context, candidateData, rejectedData) {
@@ -151,6 +153,7 @@ class BallDeckPage extends ConsumerWidget {
           : null,
       child: DragTarget<model.StorageContainer>(
         onAccept: (container) {
+          removeFromAll(ref, container);
           ref
               .read(ballDeckProvider.notifier)
               .placeIntoOverflowAt(container, overflowIndex);

--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -14,6 +14,7 @@ import '../models/plane.dart';
 import '../widgets/uld_chip.dart';
 import '../widgets/slot_layout_constants.dart';
 import '../widgets/transfer_menu.dart';
+import '../utils/uld_mover.dart';
 
 final List<Aircraft> aircraftList = [
   Aircraft('B762', 'Boeinf 767-200 Freighter', [], [
@@ -449,12 +450,13 @@ class PlanePage extends ConsumerWidget {
           : null,
       child: DragTarget<model.StorageContainer>(
         onAccept: (c) {
+          removeFromAll(ref, c);
           ref
               .read(lowerDeckProvider.notifier)
               .placeContainer(index, c, outbound: outbound);
-        ref
-            .read(planeProvider.notifier)
-            .placeLowerDeckContainer(index, c, outbound: outbound);
+          ref
+              .read(planeProvider.notifier)
+              .placeLowerDeckContainer(index, c, outbound: outbound);
         final planeId = ref.watch(selectedPlaneIdProvider);
         if (planeId != null) {
           final planes = ref.read(planesProvider);
@@ -553,6 +555,7 @@ class PlanePage extends ConsumerWidget {
           : null,
       child: DragTarget<model.StorageContainer>(
         onAccept: (c) {
+          removeFromAll(ref, c);
           ref
               .read(planeProvider.notifier)
               .placeContainer(index, c, outbound: outbound);

--- a/lib/pages/storage_page.dart
+++ b/lib/pages/storage_page.dart
@@ -6,6 +6,7 @@ import '../providers/storage_provider.dart';
 import '../widgets/uld_chip.dart';
 import '../widgets/slot_layout_constants.dart';
 import '../widgets/transfer_menu.dart';
+import '../utils/uld_mover.dart';
 
 class StoragePage extends ConsumerWidget {
   const StoragePage({super.key});
@@ -46,6 +47,7 @@ class StoragePage extends ConsumerWidget {
                   : null,
               child: DragTarget<model.StorageContainer>(
                 onAccept: (c) {
+                  removeFromAll(ref, c);
                   ref.read(storageProvider.notifier).placeContainer(index, c);
                 },
                 builder: (context, candidateData, rejectedData) {

--- a/lib/pages/train_page.dart
+++ b/lib/pages/train_page.dart
@@ -9,6 +9,7 @@ import '../providers/tug_provider.dart';
 import '../widgets/uld_chip.dart';
 import '../widgets/color_palette.dart';
 import '../widgets/transfer_menu.dart';
+import '../utils/uld_mover.dart';
 
 class TrainPage extends ConsumerWidget {
   const TrainPage({super.key});
@@ -100,6 +101,7 @@ class TrainPage extends ConsumerWidget {
                 : null,
             child: DragTarget<model.StorageContainer>(
               onAccept: (c) {
+                removeFromAll(ref, c);
                 ref
                     .read(trainProvider.notifier)
                     .assignUldToDolly(

--- a/lib/utils/uld_mover.dart
+++ b/lib/utils/uld_mover.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/container.dart';
+import '../providers/ball_deck_provider.dart';
+import '../providers/storage_provider.dart';
+import '../providers/train_provider.dart';
+import '../providers/plane_provider.dart';
+import '../providers/lower_deck_provider.dart';
+
+/// Removes the given [container] from every page before placing it elsewhere.
+void removeFromAll(WidgetRef ref, StorageContainer container) {
+  ref.read(ballDeckProvider.notifier).removeContainer(container);
+  ref.read(storageProvider.notifier).removeContainer(container);
+  ref.read(trainProvider.notifier).removeContainer(container);
+  ref.read(planeProvider.notifier).removeContainer(container, outbound: true);
+  ref.read(planeProvider.notifier).removeContainer(container, outbound: false);
+  ref
+      .read(lowerDeckProvider.notifier)
+      .removeContainer(container, outbound: true);
+  ref
+      .read(lowerDeckProvider.notifier)
+      .removeContainer(container, outbound: false);
+}

--- a/lib/widgets/transfer_area.dart
+++ b/lib/widgets/transfer_area.dart
@@ -3,11 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/container.dart';
 import '../providers/transfer_queue_provider.dart';
-import '../providers/ball_deck_provider.dart';
-import '../providers/train_provider.dart';
-import '../providers/storage_provider.dart';
-import '../providers/plane_provider.dart';
-import '../providers/lower_deck_provider.dart';
+import '../utils/uld_mover.dart';
 
 class TransferArea extends ConsumerWidget {
   const TransferArea({super.key});
@@ -18,19 +14,7 @@ class TransferArea extends ConsumerWidget {
     return DragTarget<StorageContainer>(
       onAccept: (c) {
         // Remove the ULD from wherever it currently resides
-        ref.read(ballDeckProvider.notifier).removeContainer(c);
-        ref.read(storageProvider.notifier).removeContainer(c);
-        ref.read(trainProvider.notifier).removeContainer(c);
-        ref.read(planeProvider.notifier).removeContainer(c, outbound: true);
-        ref.read(planeProvider.notifier).removeContainer(c, outbound: false);
-        ref
-            .read(planeProvider.notifier)
-            .removeLowerDeckContainer(c, outbound: true);
-        ref
-            .read(planeProvider.notifier)
-            .removeLowerDeckContainer(c, outbound: false);
-        ref.read(lowerDeckProvider.notifier).removeContainer(c, outbound: true);
-        ref.read(lowerDeckProvider.notifier).removeContainer(c, outbound: false);
+        removeFromAll(ref, c);
 
         // Finally add it to the transfer queue
         ref.read(transferQueueProvider.notifier).add(c);


### PR DESCRIPTION
## Summary
- add a helper to remove a ULD from every page
- ensure drop targets use this helper so containers are moved instead of copied
- refactor transfer area to reuse the new helper

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872ef6f4e7083318d3e51348dbaa60b