### PR TITLE
Remove TrainPage top bar

### DIFF
--- a/lib/pages/train_page.dart
+++ b/lib/pages/train_page.dart
@@ -124,10 +124,6 @@ class _TrainPageState extends ConsumerState<TrainPage>
 
     return Scaffold(
       backgroundColor: Colors.black,
-      appBar: AppBar(
-        title: const Text('Trains'),
-        backgroundColor: Colors.grey[900],
-      ),
       body: Column(
         children: [
           Container(


### PR DESCRIPTION
## Summary
- remove `AppBar` from `TrainPage` so the toggle and dropdown remain at the very top

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68782d78d7f483319ae3fe5cec1d382c