### PR TITLE
Fix unmatched parentheses in train_page Scaffold

### DIFF
--- a/lib/pages/train_page.dart
+++ b/lib/pages/train_page.dart
@@ -252,7 +252,8 @@ class _TrainPageState extends ConsumerState<TrainPage>
           const SizedBox(height: 60, child: TransferArea()),
         ],
       ),
-    );
+    ),
+  );
   }
 
   Widget _buildTug(Tug? tug) {


### PR DESCRIPTION
## Summary
- close the `SafeArea` and `Scaffold` widgets properly in `train_page.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687834eb18cc8331816108aedd72ee49