### PR TITLE
Fix 767-200 Config B slot label

### DIFF
--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -255,7 +255,7 @@ class PlanePage extends ConsumerWidget {
                         context,
                         ref,
                         index,
-                        _slotLabel(index),
+                        _slotLabel(sequence, index),
                         outbound,
                       ),
                     );
@@ -278,7 +278,7 @@ class PlanePage extends ConsumerWidget {
                         context,
                         ref,
                         index,
-                        _slotLabel(index),
+                        _slotLabel(sequence, index),
                         outbound,
                       ),
                     );
@@ -293,7 +293,7 @@ class PlanePage extends ConsumerWidget {
               context,
               ref,
               pairCount * 2,
-              _slotLabel(pairCount * 2),
+              _slotLabel(sequence, pairCount * 2),
               outbound,
             ),
           ],
@@ -311,7 +311,7 @@ class PlanePage extends ConsumerWidget {
               context,
               ref,
               i,
-              _slotLabel(i),
+              _slotLabel(sequence, i),
               outbound,
             ),
           );
@@ -508,7 +508,8 @@ class PlanePage extends ConsumerWidget {
     return 0;
   }
 
-  String _slotLabel(int index) {
+  String _slotLabel(LoadingSequence sequence, int index) {
+    if (sequence.order.length >= 21 && index == 20) return 'A11';
     if (index == 18) return 'A10';
     final row = index ~/ 2 + 1;
     final side = index % 2 == 0 ? 'L' : 'R';


### PR DESCRIPTION
## Summary
- rename the last main deck slot for the 767‑200 Config B layout
- expose sequence in `_slotLabel` so Config B can use `A11`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687846c3523883318ddc5b3b0854d47d