### PR TITLE
Fix 767-200 Config B labels

### DIFF
--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -510,6 +510,7 @@ class PlanePage extends ConsumerWidget {
 
   String _slotLabel(LoadingSequence sequence, int index) {
     if (sequence.order.length >= 21 && index == 20) return 'A11';
+    if (sequence.order.length >= 21 && index == 18) return '10L';
     if (index == 18) return 'A10';
     final row = index ~/ 2 + 1;
     final side = index % 2 == 0 ? 'L' : 'R';


### PR DESCRIPTION
## Summary
- make `10L` appear when using 21-slot config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878495543e8833189b4c6b18b594395