### PR TITLE
Add empty transfer bin button

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ void main() async {
   await Hive.openBox('trainBox');
   await Hive.openBox('tugBox');
   await Hive.openBox('planeBox');
+  await Hive.openBox('transferBox');
 
   runApp(const ProviderScope(child: RampLoaderApp()));
 }

--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -10,6 +10,7 @@ import '../providers/tug_provider.dart';
 import '../providers/train_provider.dart';
 import '../providers/ball_deck_provider.dart';
 import '../providers/storage_provider.dart';
+import '../providers/transfer_queue_provider.dart';
 import '../models/aircraft.dart';
 import '../models/tug.dart';
 import '../models/container.dart' as model;
@@ -620,6 +621,35 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
               );
             },
             child: const Text('Apply'),
+          ),
+          const SizedBox(height: 32),
+          ElevatedButton(
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  backgroundColor: Colors.grey[900],
+                  title: const Text(
+                    'Are you sure you want to permanently delete all ULDs in the Transfer Bin?',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx),
+                      child: const Text('Cancel'),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        ref.read(transferQueueProvider.notifier).clear();
+                        Navigator.pop(ctx);
+                      },
+                      child: const Text('Yes'),
+                    ),
+                  ],
+                ),
+              );
+            },
+            child: const Text('Empty Transfer Bin'),
           ),
         ],
       ),

--- a/lib/providers/transfer_queue_provider.dart
+++ b/lib/providers/transfer_queue_provider.dart
@@ -1,19 +1,44 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
 import '../models/container.dart';
 
 class TransferQueueNotifier extends StateNotifier<List<StorageContainer>> {
-  TransferQueueNotifier() : super([]);
+  final Box box;
+  static const String queueKey = 'queue';
+
+  TransferQueueNotifier(this.box) : super([]) {
+    _loadState();
+  }
+
+  void _loadState() {
+    final stored = box.get(queueKey);
+    if (stored != null && stored is List) {
+      state = List<StorageContainer>.from(stored);
+    }
+  }
+
+  void _saveState() {
+    box.put(queueKey, state);
+  }
 
   void add(StorageContainer container) {
     state = [...state, container];
+    _saveState();
   }
 
   void remove(StorageContainer container) {
     state = state.where((c) => c.id != container.id).toList();
+    _saveState();
+  }
+
+  void clear() {
+    state = [];
+    _saveState();
   }
 }
 
 final transferQueueProvider =
     StateNotifierProvider<TransferQueueNotifier, List<StorageContainer>>(
-  (ref) => TransferQueueNotifier(),
+  (ref) => TransferQueueNotifier(Hive.box('transferBox')),
 );


### PR DESCRIPTION
## Summary
- persist transfer queue in Hive and add a `clear` method
- open a new `transferBox` Hive box on startup
- add 'Empty Transfer Bin' button to Config page with confirmation dialog

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790626f9448331aced2d4a7ff69558