### PR TITLE
Remove direction toggle from train page

### DIFF
--- a/lib/models/train.dart
+++ b/lib/models/train.dart
@@ -26,20 +26,16 @@ class Train {
   final int dollyCount;
 
   @HiveField(3)
-  final List<Dolly> inboundDollys;
+  final List<Dolly> dollys;
 
   @HiveField(4)
-  final List<Dolly> outboundDollys;
-
-  @HiveField(5)
   final int colorIndex;
 
   Train({
     required this.id,
     required this.label,
     required this.dollyCount,
-    required this.inboundDollys,
-    required this.outboundDollys,
+    required this.dollys,
     required this.colorIndex,
   });
 
@@ -53,8 +49,7 @@ class Train {
       id: id,
       label: label,
       dollyCount: dollyCount,
-      inboundDollys: List.generate(dollyCount, (i) => Dolly(i + 1)),
-      outboundDollys: List.generate(dollyCount, (i) => Dolly(i + 1)),
+      dollys: List.generate(dollyCount, (i) => Dolly(i + 1)),
       colorIndex: colorIndex,
     );
   }
@@ -63,16 +58,14 @@ class Train {
     String? id,
     String? label,
     int? dollyCount,
-    List<Dolly>? inboundDollys,
-    List<Dolly>? outboundDollys,
+    List<Dolly>? dollys,
     int? colorIndex,
   }) {
     return Train(
       id: id ?? this.id,
       label: label ?? this.label,
       dollyCount: dollyCount ?? this.dollyCount,
-      inboundDollys: inboundDollys ?? this.inboundDollys,
-      outboundDollys: outboundDollys ?? this.outboundDollys,
+      dollys: dollys ?? this.dollys,
       colorIndex: colorIndex ?? this.colorIndex,
     );
   }

--- a/lib/models/train.g.dart
+++ b/lib/models/train.g.dart
@@ -57,16 +57,15 @@ class TrainAdapter extends TypeAdapter<Train> {
       id: fields[0] as String,
       label: fields[1] as String,
       dollyCount: fields[2] as int,
-      inboundDollys: (fields[3] as List).cast<Dolly>(),
-      outboundDollys: (fields[4] as List).cast<Dolly>(),
-      colorIndex: fields[5] as int,
+      dollys: (fields[3] as List).cast<Dolly>(),
+      colorIndex: fields[4] as int,
     );
   }
 
   @override
   void write(BinaryWriter writer, Train obj) {
     writer
-      ..writeByte(6)
+      ..writeByte(5)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -74,10 +73,8 @@ class TrainAdapter extends TypeAdapter<Train> {
       ..writeByte(2)
       ..write(obj.dollyCount)
       ..writeByte(3)
-      ..write(obj.inboundDollys)
+      ..write(obj.dollys)
       ..writeByte(4)
-      ..write(obj.outboundDollys)
-      ..writeByte(5)
       ..write(obj.colorIndex);
   }
 

--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -229,12 +229,10 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
                       ref.read(ballDeckProvider.notifier).addUld(container);
                       break;
                     case 'Train':
-                      final outbound = ref.read(isTrainOutboundProvider);
                       ref
                           .read(trainProvider.notifier)
                           .addToFirstAvailable(
                             container,
-                            outbound: outbound,
                           );
                       break;
                     case 'Plane':

--- a/lib/pages/train_page.dart
+++ b/lib/pages/train_page.dart
@@ -120,7 +120,6 @@ class _TrainPageState extends ConsumerState<TrainPage>
   Widget build(BuildContext context) {
     final trains = ref.watch(trainProvider);
     final tugs = ref.watch(tugProvider);
-    final outbound = ref.watch(isTrainOutboundProvider);
 
     const topBarHeight = 60.0;
 
@@ -183,13 +182,6 @@ class _TrainPageState extends ConsumerState<TrainPage>
                   },
                 ),
                 const SizedBox(width: 16),
-                const Text('Inbound', style: TextStyle(color: Colors.white)),
-                Switch(
-                  value: outbound,
-                  onChanged: (val) =>
-                      ref.read(isTrainOutboundProvider.notifier).state = val,
-                ),
-                const Text('Outbound', style: TextStyle(color: Colors.white)),
                 const SizedBox(width: 8),
                 ElevatedButton(
                   onPressed: _applyChanges,
@@ -235,7 +227,6 @@ class _TrainPageState extends ConsumerState<TrainPage>
                                   child: _buildDollyStack(
                                     context,
                                     train,
-                                    outbound,
                                   ),
                                 ),
                               ],
@@ -280,13 +271,12 @@ class _TrainPageState extends ConsumerState<TrainPage>
     );
   }
 
-  Widget _buildDollyStack(BuildContext context, Train train, bool outbound) {
+  Widget _buildDollyStack(BuildContext context, Train train) {
     return ListView.builder(
       padding: EdgeInsets.zero,
       itemCount: train.dollyCount,
       itemBuilder: (context, index) {
-        final dolly =
-            outbound ? train.outboundDollys[index] : train.inboundDollys[index];
+        final dolly = train.dollys[index];
         final uld = dolly.load;
         return GestureDetector(
           onLongPressStart: uld == null
@@ -299,7 +289,6 @@ class _TrainPageState extends ConsumerState<TrainPage>
                             trainId: train.id,
                             dollyIdx: index,
                             container: c,
-                            outbound: outbound,
                           );
                     },
                   )
@@ -311,7 +300,6 @@ class _TrainPageState extends ConsumerState<TrainPage>
                     trainId: train.id,
                     dollyIdx: index,
                     container: c,
-                    outbound: outbound,
                   );
             },
             builder: (context, candidateData, rejectedData) {

--- a/lib/providers/train_provider.dart
+++ b/lib/providers/train_provider.dart
@@ -27,9 +27,8 @@ class TrainNotifier extends StateNotifier<List<Train>> {
       // If it's a new day, clear the ULDs but keep config
       if (lastOpened != today) {
         for (final train in loaded) {
-          for (int i = 0; i < train.inboundDollys.length; i++) {
-            train.inboundDollys[i] = Dolly(train.inboundDollys[i].idx);
-            train.outboundDollys[i] = Dolly(train.outboundDollys[i].idx);
+          for (int i = 0; i < train.dollys.length; i++) {
+            train.dollys[i] = Dolly(train.dollys[i].idx);
           }
         }
       }
@@ -72,17 +71,11 @@ class TrainNotifier extends StateNotifier<List<Train>> {
     required String trainId,
     required int dollyIdx,
     required StorageContainer container,
-    required bool outbound,
   }) {
     final trains = [...state];
     final train = trains.firstWhere((t) => t.id == trainId);
-    if (outbound) {
-      final dolly = train.outboundDollys[dollyIdx];
-      train.outboundDollys[dollyIdx] = Dolly(dolly.idx, load: container);
-    } else {
-      final dolly = train.inboundDollys[dollyIdx];
-      train.inboundDollys[dollyIdx] = Dolly(dolly.idx, load: container);
-    }
+    final dolly = train.dollys[dollyIdx];
+    train.dollys[dollyIdx] = Dolly(dolly.idx, load: container);
     state = trains;
     _saveState();
   }
@@ -90,17 +83,11 @@ class TrainNotifier extends StateNotifier<List<Train>> {
   void clearUldFromDolly({
     required String trainId,
     required int dollyIdx,
-    required bool outbound,
   }) {
     final trains = [...state];
     final train = trains.firstWhere((t) => t.id == trainId);
-    if (outbound) {
-      final dolly = train.outboundDollys[dollyIdx];
-      train.outboundDollys[dollyIdx] = Dolly(dolly.idx);
-    } else {
-      final dolly = train.inboundDollys[dollyIdx];
-      train.inboundDollys[dollyIdx] = Dolly(dolly.idx);
-    }
+    final dolly = train.dollys[dollyIdx];
+    train.dollys[dollyIdx] = Dolly(dolly.idx);
     state = trains;
     _saveState();
   }
@@ -111,13 +98,9 @@ class TrainNotifier extends StateNotifier<List<Train>> {
     bool changed = false;
     for (int t = 0; t < trains.length; t++) {
       final train = trains[t];
-      for (int i = 0; i < train.inboundDollys.length; i++) {
-        if (train.inboundDollys[i].load?.id == container.id) {
-          train.inboundDollys[i] = Dolly(train.inboundDollys[i].idx);
-          changed = true;
-        }
-        if (train.outboundDollys[i].load?.id == container.id) {
-          train.outboundDollys[i] = Dolly(train.outboundDollys[i].idx);
+      for (int i = 0; i < train.dollys.length; i++) {
+        if (train.dollys[i].load?.id == container.id) {
+          train.dollys[i] = Dolly(train.dollys[i].idx);
           changed = true;
         }
       }
@@ -130,13 +113,12 @@ class TrainNotifier extends StateNotifier<List<Train>> {
 
   /// Adds a [container] to the first available dolly starting from the first
   /// train. If all dollies are occupied the container is ignored.
-  void addToFirstAvailable(StorageContainer container, {required bool outbound}) {
+  void addToFirstAvailable(StorageContainer container) {
     final trains = [...state];
     for (final train in trains) {
-      final list = outbound ? train.outboundDollys : train.inboundDollys;
-      for (int i = 0; i < list.length; i++) {
-        if (list[i].load == null) {
-          list[i] = Dolly(list[i].idx, load: container);
+      for (int i = 0; i < train.dollys.length; i++) {
+        if (train.dollys[i].load == null) {
+          train.dollys[i] = Dolly(train.dollys[i].idx, load: container);
           state = trains;
           _saveState();
           return;
@@ -145,5 +127,3 @@ class TrainNotifier extends StateNotifier<List<Train>> {
     }
   }
 }
-
-final isTrainOutboundProvider = StateProvider<bool>((ref) => false);


### PR DESCRIPTION
## Summary
- simplify Train model to track a single list of dollys
- drop inbound/outbound logic from `TrainPage`
- remove direction-aware state from `TrainNotifier`
- adjust config page to add ULDs to trains without direction

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68795430964c83318473dc7d103a19b9