### PR TITLE
Add duplicate ULD check with location-aware alert

### DIFF
--- a/lib/pages/ball_deck_page.dart
+++ b/lib/pages/ball_deck_page.dart
@@ -10,6 +10,7 @@ import '../models/aircraft.dart';
 import '../widgets/slot_layout_constants.dart';
 import '../widgets/transfer_menu.dart';
 import '../utils/uld_mover.dart';
+import '../utils/duplicate_checker.dart';
 
 class BallDeckPage extends ConsumerWidget {
   const BallDeckPage({super.key});
@@ -231,22 +232,41 @@ class _AddUldDialogState extends ConsumerState<AddUldDialog> {
         TextButton(
           onPressed: () {
             final label = _idController.text.trim();
-            if (label.isNotEmpty) {
-              ref
-                  .read(ballDeckProvider.notifier)
-                  .addUld(
-                    model.StorageContainer(
-                      id: UniqueKey().toString(),
-                      uld: label,
-                      type: SizeEnum.Custom,
-                      size: SizeEnum.PAG_88x125,
-                      weightKg: 0,
-                      hasDangerousGoods: false,
-                      colorIndex: 0,
+            if (label.isEmpty) return;
+
+            final location = findUldLocation(ref, label);
+            if (location != null) {
+              showDialog(
+                context: context,
+                builder: (_) => AlertDialog(
+                  backgroundColor: Colors.black,
+                  content: Text(
+                    'That ULD already exists at $location',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context),
+                      child: const Text('Ok'),
                     ),
-                  );
-              Navigator.pop(context);
+                  ],
+                ),
+              );
+              return;
             }
+
+            ref.read(ballDeckProvider.notifier).addUld(
+                  model.StorageContainer(
+                    id: UniqueKey().toString(),
+                    uld: label,
+                    type: SizeEnum.Custom,
+                    size: SizeEnum.PAG_88x125,
+                    weightKg: 0,
+                    hasDangerousGoods: false,
+                    colorIndex: 0,
+                  ),
+                );
+            Navigator.pop(context);
           },
           child: const Text('Add', style: TextStyle(color: Colors.amber)),
         ),

--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -17,6 +17,7 @@ import '../models/container.dart' as model;
 import '../models/uld_type.dart';
 import '../widgets/color_picker_dialog.dart';
 import '../widgets/color_palette.dart';
+import '../utils/duplicate_checker.dart';
 
 class TugDraft {
   String id;
@@ -211,6 +212,29 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
             actions: [
               TextButton(
                 onPressed: () {
+                  if (name.trim().isEmpty) return;
+
+                  final location = findUldLocation(ref, name);
+                  if (location != null) {
+                    showDialog(
+                      context: context,
+                      builder: (_) => AlertDialog(
+                        backgroundColor: Colors.black,
+                        content: Text(
+                          'That ULD already exists at $location',
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.pop(context),
+                            child: const Text('Ok'),
+                          ),
+                        ],
+                      ),
+                    );
+                    return;
+                  }
+
                   final container = model.StorageContainer(
                     id: UniqueKey().toString(),
                     uld: name,

--- a/lib/utils/duplicate_checker.dart
+++ b/lib/utils/duplicate_checker.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/container.dart';
+import '../models/plane.dart';
+import '../providers/ball_deck_provider.dart';
+import '../providers/storage_provider.dart';
+import '../providers/train_provider.dart';
+import '../providers/plane_provider.dart';
+import '../providers/planes_provider.dart';
+
+/// Returns a description of where a ULD with [label] currently exists,
+/// or `null` if the label is unused.
+String? findUldLocation(WidgetRef ref, String label) {
+  label = label.trim();
+  if (label.isEmpty) return null;
+
+  final ballDeck = ref.read(ballDeckProvider);
+  for (final slot in ballDeck.slots) {
+    if (slot?.uld == label) return 'Ball Deck';
+  }
+  for (final c in ballDeck.overflow) {
+    if (c.uld == label) return 'Ball Deck';
+  }
+
+  final storage = ref.read(storageProvider);
+  for (final c in storage) {
+    if (c?.uld == label) return 'Storage Page';
+  }
+
+  final trains = ref.read(trainProvider);
+  for (final train in trains) {
+    for (final dolly in train.dollys) {
+      if (dolly.load?.uld == label) {
+        return 'Train Page';
+      }
+    }
+  }
+
+  final planeState = ref.read(planeProvider);
+  final selectedId = ref.read(selectedPlaneIdProvider);
+  Plane? selectedPlane;
+  final planes = ref.read(planesProvider);
+  if (selectedId != null) {
+    try {
+      selectedPlane = planes.firstWhere((p) => p.id == selectedId);
+    } catch (_) {}
+  }
+
+  // Check current plane state (unsaved changes)
+  String planeName = selectedPlane?.name ?? 'Plane';
+  for (final c in planeState.inboundSlots) {
+    if (c?.uld == label) return '$planeName, Inbound, Main Deck';
+  }
+  for (final c in planeState.outboundSlots) {
+    if (c?.uld == label) return '$planeName, Outbound, Main Deck';
+  }
+  for (final c in planeState.lowerInboundSlots) {
+    if (c?.uld == label) return '$planeName, Inbound, Lower Deck';
+  }
+  for (final c in planeState.lowerOutboundSlots) {
+    if (c?.uld == label) return '$planeName, Outbound, Lower Deck';
+  }
+
+  // Check all persisted planes
+  for (final plane in planes) {
+    for (final c in plane.inboundSlots) {
+      if (c?.uld == label) return '${plane.name}, Inbound, Main Deck';
+    }
+    for (final c in plane.outboundSlots) {
+      if (c?.uld == label) return '${plane.name}, Outbound, Main Deck';
+    }
+    for (final c in plane.lowerInboundSlots) {
+      if (c?.uld == label) return '${plane.name}, Inbound, Lower Deck';
+    }
+    for (final c in plane.lowerOutboundSlots) {
+      if (c?.uld == label) return '${plane.name}, Outbound, Lower Deck';
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- prevent creating duplicate ULD labels
- add helper `findUldLocation` to lookup an existing ULD's location
- integrate duplicate check in Ball Deck and Config page ULD creation dialogs

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68795b8df0d8833180ae34d807b1a77f