### PR TITLE
Handle removed slots with transfer bin across pages

### DIFF
--- a/lib/pages/ball_deck_page.dart
+++ b/lib/pages/ball_deck_page.dart
@@ -9,6 +9,7 @@ import '../widgets/uld_chip.dart';
 import '../models/aircraft.dart';
 import '../widgets/slot_layout_constants.dart';
 import '../widgets/transfer_menu.dart';
+import '../widgets/transfer_area.dart';
 import '../utils/uld_mover.dart';
 import '../utils/duplicate_checker.dart';
 
@@ -22,10 +23,13 @@ class BallDeckPage extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Ball Deck')),
       backgroundColor: Colors.black,
-      body: Padding(
-        padding: slotPadding,
-        child: SingleChildScrollView(
-          child: Column(
+      body: Column(
+        children: [
+          Expanded(
+            child: Padding(
+              padding: slotPadding,
+              child: SingleChildScrollView(
+                child: Column(
             children: List.generate(ballDeck.slots.length, (index) {
               final slotUld = ballDeck.slots[index];
               final overflowStartIndex = index * 2;
@@ -63,8 +67,12 @@ class BallDeckPage extends ConsumerWidget {
                 ),
               );
             }),
+                ),
+              ),
+            ),
           ),
-        ),
+          const SizedBox(height: 60, child: TransferArea()),
+        ],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {

--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -344,7 +344,12 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
       if (inboundSlots.length < oldInbound.length) {
         for (int i = inboundSlots.length; i < oldInbound.length; i++) {
           final c = oldInbound[i];
-          if (c != null) transfer.add(c);
+          if (c != null) {
+            transfer.add(c);
+            // Debug print for removed inbound ULDs
+            // ignore: avoid_print
+            print('ULD ${c.uld} moved to Transfer Bin due to slot removal');
+          }
         }
       }
 
@@ -357,7 +362,12 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
       if (outboundSlots.length < oldOutbound.length) {
         for (int i = outboundSlots.length; i < oldOutbound.length; i++) {
           final c = oldOutbound[i];
-          if (c != null) transfer.add(c);
+          if (c != null) {
+            transfer.add(c);
+            // Debug print for removed outbound ULDs
+            // ignore: avoid_print
+            print('ULD ${c.uld} moved to Transfer Bin due to slot removal');
+          }
         }
       }
     }

--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -14,6 +14,7 @@ import '../models/plane.dart';
 import '../widgets/uld_chip.dart';
 import '../widgets/slot_layout_constants.dart';
 import '../widgets/transfer_menu.dart';
+import '../widgets/transfer_area.dart';
 import '../utils/uld_mover.dart';
 
 final List<Aircraft> aircraftList = [
@@ -193,21 +194,27 @@ class PlanePage extends ConsumerWidget {
             ),
         ],
       ),
-      body:
-          aircraft == null || sequence == null
-              ? const Center(
-                child: Text(
-                  'Please select a plane and configuration using the dropdowns above.',
-                  style: TextStyle(color: Colors.white70),
-                  textAlign: TextAlign.center,
-                ),
-              )
-              : SingleChildScrollView(
-                padding: slotPadding,
-                child: isLowerDeck
-                    ? _buildLowerDeckLayout(context, ref, isOutbound)
-                    : _buildLayout(context, ref, sequence, isOutbound),
-              ),
+      body: Column(
+        children: [
+          Expanded(
+            child: aircraft == null || sequence == null
+                ? const Center(
+                    child: Text(
+                      'Please select a plane and configuration using the dropdowns above.',
+                      style: TextStyle(color: Colors.white70),
+                      textAlign: TextAlign.center,
+                    ),
+                  )
+                : SingleChildScrollView(
+                    padding: slotPadding,
+                    child: isLowerDeck
+                        ? _buildLowerDeckLayout(context, ref, isOutbound)
+                        : _buildLayout(context, ref, sequence, isOutbound),
+                  ),
+          ),
+          const SizedBox(height: 60, child: TransferArea()),
+        ],
+      ),
     );
   }
 

--- a/lib/pages/storage_page.dart
+++ b/lib/pages/storage_page.dart
@@ -6,6 +6,7 @@ import '../providers/storage_provider.dart';
 import '../widgets/uld_chip.dart';
 import '../widgets/slot_layout_constants.dart';
 import '../widgets/transfer_menu.dart';
+import '../widgets/transfer_area.dart';
 import '../utils/uld_mover.dart';
 
 class StoragePage extends ConsumerWidget {
@@ -24,9 +25,12 @@ class StoragePage extends ConsumerWidget {
         title: const Text('Storage'),
         backgroundColor: Colors.black,
       ),
-      body: SingleChildScrollView(
-        padding: slotPadding,
-        child: Wrap(
+      body: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              padding: slotPadding,
+              child: Wrap(
           spacing: slotSpacing,
           runSpacing: slotRunSpacing,
           children: List.generate(slots.length, (index) {
@@ -86,6 +90,9 @@ class StoragePage extends ConsumerWidget {
             );
           }),
         ),
+          ),
+          const SizedBox(height: 60, child: TransferArea()),
+        ],
       ),
     );
   }

--- a/lib/pages/train_page.dart
+++ b/lib/pages/train_page.dart
@@ -126,7 +126,12 @@ class _TrainPageState extends ConsumerState<TrainPage>
       if (existing != null && draft.dollyCount < existing.dollys.length) {
         for (int i = draft.dollyCount; i < existing.dollys.length; i++) {
           final c = existing.dollys[i].load;
-          if (c != null) transfer.add(c);
+          if (c != null) {
+            transfer.add(c);
+            // Debug print for removed train dolly ULDs
+            // ignore: avoid_print
+            print('ULD ${c.uld} moved to Transfer Bin due to slot removal');
+          }
         }
       }
       return Train(
@@ -143,7 +148,12 @@ class _TrainPageState extends ConsumerState<TrainPage>
       if (!exists) {
         for (final d in t.dollys) {
           final c = d.load;
-          if (c != null) transfer.add(c);
+          if (c != null) {
+            transfer.add(c);
+            // Debug print for removed train
+            // ignore: avoid_print
+            print('ULD ${c.uld} moved to Transfer Bin due to slot removal');
+          }
         }
       }
     }

--- a/lib/providers/ball_deck_provider.dart
+++ b/lib/providers/ball_deck_provider.dart
@@ -34,7 +34,12 @@ class BallDeckNotifier extends StateNotifier<BallDeckState> {
     if (count < oldSlots.length && transferQueue != null) {
       for (int i = count; i < oldSlots.length; i++) {
         final c = oldSlots[i];
-        if (c != null) transferQueue.add(c);
+        if (c != null) {
+          transferQueue.add(c);
+          // Debug print to verify transfer logic
+          // ignore: avoid_print
+          print('ULD ${c.uld} moved to Transfer Bin due to slot removal');
+        }
       }
     }
     state = BallDeckState(slots: updatedSlots, overflow: state.overflow);

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -23,7 +23,12 @@ class StorageNotifier extends StateNotifier<List<StorageContainer?>> {
     if (count < oldState.length && transferQueue != null) {
       for (int i = count; i < oldState.length; i++) {
         final c = oldState[i];
-        if (c != null) transferQueue.add(c);
+        if (c != null) {
+          transferQueue.add(c);
+          // Debug print
+          // ignore: avoid_print
+          print('ULD ${c.uld} moved to Transfer Bin due to slot removal');
+        }
       }
     }
     state = newState;


### PR DESCRIPTION
## Summary
- add debug prints when ULDs are moved to the Transfer Bin
- propagate TransferArea widget to Ball Deck, Plane, and Storage pages
- ensure slot adjustments in plane, train, ball deck, and storage move displaced ULDs into the transfer queue

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a4dc586408331984a7fd3b81d6ea5