### PR TITLE
Fix storage page layout and set NDK version

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,6 +9,7 @@ android {
     namespace = "com.example.ramp_loader_app"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/lib/pages/storage_page.dart
+++ b/lib/pages/storage_page.dart
@@ -31,9 +31,9 @@ class StoragePage extends ConsumerWidget {
             child: SingleChildScrollView(
               padding: slotPadding,
               child: Wrap(
-          spacing: slotSpacing,
-          runSpacing: slotRunSpacing,
-          children: List.generate(slots.length, (index) {
+                spacing: slotSpacing,
+                runSpacing: slotRunSpacing,
+                children: List.generate(slots.length, (index) {
             final container = slots[index];
 
             return GestureDetector(
@@ -90,8 +90,9 @@ class StoragePage extends ConsumerWidget {
             );
           }),
         ),
+        ),
           ),
-          const SizedBox(height: 60, child: TransferArea()),
+        const SizedBox(height: 60, child: TransferArea()),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- fix `Expanded` widget usage in `storage_page.dart`
- specify Android NDK version in build.gradle.kts

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a502f7c308331b9322e59cd700e26