### PR TITLE
Fix transfer bin duplication and improve ball deck slot resize

### DIFF
--- a/lib/pages/ball_deck_page.dart
+++ b/lib/pages/ball_deck_page.dart
@@ -71,7 +71,6 @@ class BallDeckPage extends ConsumerWidget {
               ),
             ),
           ),
-          const SizedBox(height: 60, child: TransferArea()),
         ],
       ),
       floatingActionButton: FloatingActionButton(

--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -544,23 +544,33 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
             onChanged: (value) => setState(() => ballDeckCount = value.toInt()),
           ),
           ElevatedButton(
-            onPressed:
-                (ballDeckCount != ballDeck.slots.length)
-                    ? () {
-                      ref
-                          .read(ballDeckProvider.notifier)
-                          .setSlotCount(
-                            ballDeckCount,
-                            transferQueue:
-                                ref.read(transferQueueProvider.notifier),
-                          );
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text('Ball Deck slot count updated'),
-                        ),
-                      );
+            onPressed: (ballDeckCount != ballDeck.slots.length)
+                ? () {
+                    final transfer =
+                        ref.read(transferQueueProvider.notifier);
+                    // Move ULDs from removed slots to the Transfer Bin
+                    if (ballDeckCount < ballDeck.slots.length) {
+                      for (int i = ballDeckCount;
+                          i < ballDeck.slots.length;
+                          i++) {
+                        final c = ballDeck.slots[i];
+                        if (c != null) {
+                          transfer.add(c);
+                        }
+                      }
                     }
-                    : null,
+
+                    ref
+                        .read(ballDeckProvider.notifier)
+                        .setSlotCount(ballDeckCount);
+
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Ball Deck slot count updated'),
+                      ),
+                    );
+                  }
+                : null,
             child: const Text('Apply'),
           ),
           const SizedBox(height: 24),

--- a/lib/providers/ball_deck_provider.dart
+++ b/lib/providers/ball_deck_provider.dart
@@ -18,8 +18,18 @@ class BallDeckState {
 }
 
 class BallDeckNotifier extends StateNotifier<BallDeckState> {
-  BallDeckNotifier()
-    : super(BallDeckState(slots: List.filled(7, null), overflow: []));
+  final Box _box = Hive.box('ballDeckBox');
+  static const String stateKey = 'state';
+
+  BallDeckNotifier() : super(_loadInitial(Hive.box('ballDeckBox')));
+
+  static BallDeckState _loadInitial(Box box) {
+    final stored = box.get(stateKey);
+    if (stored != null && stored is BallDeckState) {
+      return stored;
+    }
+    return BallDeckState(slots: List.filled(7, null), overflow: []);
+  }
 
   void setSlotCount(
     int count, {
@@ -168,7 +178,7 @@ class BallDeckNotifier extends StateNotifier<BallDeckState> {
   }
 
   void _saveState() {
-    // You can implement Hive or other persistence logic here
+    _box.put(stateKey, state);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate `TransferArea` from `BallDeckPage`
- move displaced ULDs to the Transfer Bin before resizing slots
- persist Ball Deck state using Hive

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a53b36c648331ba78f8d11822882f