### PR TITLE
Add SizeEnum Hive adapter and clamp slider values

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import 'models/container.dart' as model;
+import 'models/size_enum_adapter.dart';
 import 'models/train.dart';
 import 'models/tug.dart';
 import 'models/plane.dart';
@@ -18,6 +19,7 @@ void main() async {
   await Hive.initFlutter();
 
   // Register Hive adapters
+  Hive.registerAdapter(SizeEnumAdapter());
   Hive.registerAdapter(model.StorageContainerAdapter());
   Hive.registerAdapter(DollyAdapter());
   Hive.registerAdapter(TrainAdapter());

--- a/lib/models/size_enum_adapter.dart
+++ b/lib/models/size_enum_adapter.dart
@@ -1,0 +1,19 @@
+import 'package:hive/hive.dart';
+
+import 'aircraft.dart';
+
+class SizeEnumAdapter extends TypeAdapter<SizeEnum> {
+  @override
+  final int typeId = 5;
+
+  @override
+  SizeEnum read(BinaryReader reader) {
+    final index = reader.read() as int;
+    return SizeEnum.values[index];
+  }
+
+  @override
+  void write(BinaryWriter writer, SizeEnum obj) {
+    writer.write(obj.index);
+  }
+}

--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -521,7 +521,7 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
             style: TextStyle(color: Colors.white),
           ),
           Slider(
-            value: ballDeckCount.toDouble(),
+            value: ballDeckCount.toDouble().clamp(1, 25),
             min: 1,
             max: 25,
             divisions: 24,
@@ -594,7 +594,7 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
             style: TextStyle(color: Colors.white, fontSize: 18),
           ),
           Slider(
-            value: tugCount.toDouble(),
+            value: tugCount.toDouble().clamp(0, 25),
             min: 0,
             max: 25,
             divisions: 25,
@@ -679,7 +679,7 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
           const SizedBox(height: 32),
           const Text('🏬 Storage Slots', style: TextStyle(color: Colors.white)),
           Slider(
-            value: storageCount.toDouble(),
+            value: storageCount.toDouble().clamp(0, 50),
             min: 0,
             max: 50,
             divisions: 50,


### PR DESCRIPTION
## Summary
- create a Hive `TypeAdapter` for `SizeEnum`
- register the new adapter at startup
- clamp slider values to stay in their allowed range

## Testing
- `dart format lib/models/size_enum_adapter.dart lib/main.dart lib/pages/config_page.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6911d2e08331b47426b478460304